### PR TITLE
Fix error in babel config

### DIFF
--- a/chels-portfolio/babel.config.js
+++ b/chels-portfolio/babel.config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  presets: ["@vue/cli-plugin-babel/preset"],
-  lintOnSave: false
+  presets: ["@vue/cli-plugin-babel/preset"]
 };


### PR DESCRIPTION
removing the `lintOnSave` from `babel.config.js` file

`lintOnSave` is something that's an `eslint` option, not a `babel` option :(